### PR TITLE
Added support for self-hosted instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alfred-outline
 
-An Alfred workflow to search your team Outline from the comfort of your desktop. 
+An Alfred workflow to search your team Outline from the comfort of your desktop.
 
 Simply type your keyword into Alfred (default: ou) to see instant search results from your Outline knowledge base. Selecting a search result takes you directly to that Outline document in your default web browser.
 
@@ -21,7 +21,7 @@ $ npm install --global alfred-outline
 ## Workflow Variables
 
 - `apiToken`: Grab a personal API token from the settings page in Outline: https://www.getoutline.com/settings/tokens
-- `subdomain`: This should be your just your teams Outline subdomain, whatever is listed between the protocol and getoutline.com in your browsers address bar: https://\<SUBDOMAIN\>.getoutline.com
+- `domain`: This should be your just your teams Outline domain(\<TEAM-SUBDOMAIN\>.getoutline.com) for getoutline.com managed instances and https://\<DOMAIN\> for self-hosted instances.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install --global alfred-outline
 ## Workflow Variables
 
 - `apiToken`: Grab a personal API token from the settings page in Outline: `https://www.getoutline.com/settings/tokens` or `https://\<DOMAIN\>/settings/tokens`
-- `domain`: This should be your just your teams Outline domain (\<TEAM-SUBDOMAIN\>.getoutline.com) for getoutline.com managed instances and https://\<DOMAIN\> for self-hosted instances.
+- `domain`: This should be your just your teams Outline domain (`\<TEAM-SUBDOMAIN\>.getoutline.com`) for getoutline.com managed instances and `https://\<DOMAIN\>` for self-hosted instances.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ $ npm install --global alfred-outline
 
 ## Workflow Variables
 
-- `apiToken`: Grab a personal API token from the settings page in Outline: https://www.getoutline.com/settings/tokens
-- `domain`: This should be your just your teams Outline domain(\<TEAM-SUBDOMAIN\>.getoutline.com) for getoutline.com managed instances and https://\<DOMAIN\> for self-hosted instances.
+- `apiToken`: Grab a personal API token from the settings page in Outline: `https://www.getoutline.com/settings/tokens` or `https://\<DOMAIN\>/settings/tokens`
+- `domain`: This should be your just your teams Outline domain (\<TEAM-SUBDOMAIN\>.getoutline.com) for getoutline.com managed instances and https://\<DOMAIN\> for self-hosted instances.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ const results = await alfy.fetch(`${process.env.domain || "www.getoutline.com"}/
 let items = results.data.map(result => ({
   title: result.document.title,
   subtitle: result.context.replace(/\<\/?b\>/g, ''),
-  // arg: `https://${process.env.subdomain || "www"}.getoutline.com${result.document.url}`,
   arg: `https://${process.env.domain || "www.getoutline.com"}${result.document.url}`,
   icon: {
     path: path.join(__dirname, "document.png")
@@ -25,7 +24,6 @@ let items = results.data.map(result => ({
 if (!items.length) {
   items = [{
     title: "No results - go to Outline homepage",
-    // arg: `https://${process.env.subdomain || "www"}.getoutline.com/home`
     arg: `https://${process.env.domain || "www.getoutline.com"}`
   }];
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const path = require('path');
 const alfy = require('alfy');
 
-const results = await alfy.fetch(`${process.env.domain || "app.getoutline.com"}/api/documents.search`, {
+const protocolAndHost = `https://${process.env.domain || "app.getoutline.com"}`;
+
+const results = await alfy.fetch(`${protocolAndHost}/api/documents.search`, {
   method: "POST",
   headers: {
     Authorization: `Bearer ${process.env.apiToken}`,
@@ -15,7 +17,7 @@ const results = await alfy.fetch(`${process.env.domain || "app.getoutline.com"}/
 let items = results.data.map(result => ({
   title: result.document.title,
   subtitle: result.context.replace(/\<\/?b\>/g, ''),
-  arg: `https://${process.env.domain || "app.getoutline.com"}${result.document.url}`,
+  arg: `${protocolAndHost}${result.document.url}`,
   icon: {
     path: path.join(__dirname, "document.png")
   }
@@ -24,7 +26,7 @@ let items = results.data.map(result => ({
 if (!items.length) {
   items = [{
     title: "No results - go to Outline homepage",
-    arg: `https://${process.env.domain || "app.getoutline.com"}`
+    arg: `${protocolAndHost}/home`
   }];
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const alfy = require('alfy');
 
-const results = await alfy.fetch(`https://www.getoutline.com/api/documents.search`, {
+const results = await alfy.fetch(`${process.env.subdomain || "www.getoutline.com"}/api/documents.search`, {
   method: "POST",
   headers: {
     Authorization: `Bearer ${process.env.apiToken}`,
@@ -15,7 +15,8 @@ const results = await alfy.fetch(`https://www.getoutline.com/api/documents.searc
 let items = results.data.map(result => ({
   title: result.document.title,
   subtitle: result.context.replace(/\<\/?b\>/g, ''),
-  arg: `https://${process.env.subdomain || "www"}.getoutline.com${result.document.url}`,
+  // arg: `https://${process.env.subdomain || "www"}.getoutline.com${result.document.url}`,
+  arg: `https://${process.env.subdomain || "www.getoutline.com"}${result.document.url}`,
   icon: {
     path: path.join(__dirname, "document.png")
   }
@@ -24,7 +25,8 @@ let items = results.data.map(result => ({
 if (!items.length) {
   items = [{
     title: "No results - go to Outline homepage",
-    arg: `https://${process.env.subdomain || "www"}.getoutline.com/home`
+    // arg: `https://${process.env.subdomain || "www"}.getoutline.com/home`
+    arg: `https://${process.env.subdomain || "www.getoutline.com"}`
   }];
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const alfy = require('alfy');
 
-const results = await alfy.fetch(`${process.env.subdomain || "www.getoutline.com"}/api/documents.search`, {
+const results = await alfy.fetch(`${process.env.domain || "www.getoutline.com"}/api/documents.search`, {
   method: "POST",
   headers: {
     Authorization: `Bearer ${process.env.apiToken}`,
@@ -16,7 +16,7 @@ let items = results.data.map(result => ({
   title: result.document.title,
   subtitle: result.context.replace(/\<\/?b\>/g, ''),
   // arg: `https://${process.env.subdomain || "www"}.getoutline.com${result.document.url}`,
-  arg: `https://${process.env.subdomain || "www.getoutline.com"}${result.document.url}`,
+  arg: `https://${process.env.domain || "www.getoutline.com"}${result.document.url}`,
   icon: {
     path: path.join(__dirname, "document.png")
   }
@@ -26,7 +26,7 @@ if (!items.length) {
   items = [{
     title: "No results - go to Outline homepage",
     // arg: `https://${process.env.subdomain || "www"}.getoutline.com/home`
-    arg: `https://${process.env.subdomain || "www.getoutline.com"}`
+    arg: `https://${process.env.domain || "www.getoutline.com"}`
   }];
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const alfy = require('alfy');
 
-const results = await alfy.fetch(`${process.env.domain || "www.getoutline.com"}/api/documents.search`, {
+const results = await alfy.fetch(`${process.env.domain || "app.getoutline.com"}/api/documents.search`, {
   method: "POST",
   headers: {
     Authorization: `Bearer ${process.env.apiToken}`,
@@ -15,7 +15,7 @@ const results = await alfy.fetch(`${process.env.domain || "www.getoutline.com"}/
 let items = results.data.map(result => ({
   title: result.document.title,
   subtitle: result.context.replace(/\<\/?b\>/g, ''),
-  arg: `https://${process.env.domain || "www.getoutline.com"}${result.document.url}`,
+  arg: `https://${process.env.domain || "app.getoutline.com"}${result.document.url}`,
   icon: {
     path: path.join(__dirname, "document.png")
   }
@@ -24,7 +24,7 @@ let items = results.data.map(result => ({
 if (!items.length) {
   items = [{
     title: "No results - go to Outline homepage",
-    arg: `https://${process.env.domain || "www.getoutline.com"}`
+    arg: `https://${process.env.domain || "app.getoutline.com"}`
   }];
 }
 

--- a/info.plist
+++ b/info.plist
@@ -125,12 +125,12 @@
 	<dict>
 		<key>apiToken</key>
 		<string></string>
-		<key>subdomain</key>
+		<key>domain</key>
 		<string></string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>
-		<string>subdomain</string>
+		<string>domain</string>
 		<string>apiToken</string>
 	</array>
 	<key>version</key>


### PR DESCRIPTION
I was able to get Alfred 4 (v4.1.1) on macOS (10.15.6) to search my self-hosted Outline instance by making minor changes as is reflected in the 4 commits. Please accept if this is reasonable. Thanks for the great piece of software and this plugin!

![ScreenShot](https://user-images.githubusercontent.com/4934310/92527240-3fb12e00-f216-11ea-8c5e-c40a773c89c6.png)
